### PR TITLE
refactor:exclude queries and sqlc generated files from gitignore

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -65,7 +65,7 @@ pgdata/
 *.db
 
 # SQL dumps & backups
-*.sql
+!*.sql
 *.dump
 *.backup
 
@@ -74,7 +74,7 @@ pgdata/
 ############################################
 # Uploaded photos
 uploads/
-storage/
+!storage/
 media/
 photos/
 thumbnails/

--- a/backend/internal/domains/files/infrastructure/storage/local_storage.go
+++ b/backend/internal/domains/files/infrastructure/storage/local_storage.go
@@ -1,0 +1,1 @@
+package storage

--- a/backend/internal/domains/files/infrastructure/storage/s3_storage.go
+++ b/backend/internal/domains/files/infrastructure/storage/s3_storage.go
@@ -1,0 +1,1 @@
+package storage


### PR DESCRIPTION
## What
Removed sql queries and sqlc generated files from .gitignore 
## Why
- They are safe to be pushed to GitHub
