### PR TITLE
chore: add environment dynamically depending on branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ env:
 jobs:
   test:
     name: Test & Build Application
-    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     outputs:
       coverage: ${{ steps.coverage.outputs.percentage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   test:
     name: Test & Build Application
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     outputs:
       coverage: ${{ steps.coverage.outputs.percentage }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   deploy-render-production:
     name: Deploy to Render Production
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     # This job only runs if the payload branch matches 'main'
     if: github.event.client_payload.branch == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   deploy-render-staging:
     name: Deploy to Render Staging
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     # This job only runs if the payload branch matches 'dev'
     if: github.event.client_payload.branch == 'refs/heads/dev'
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   build:
     name: Build & Push Image
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   migrate:
     name: Run Database Migrations
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     # This job only runs if the payload branch matches 'main'
     if: github.event.client_payload.branch == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR add environment dynamically to workflows as shown by the following snippet:
```bash
environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
```

## Why is this change needed?
This change is required for the secrets set under `production` and `staging` environments to work.

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Linter passes
