### PR TITLE
remove environment from docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,6 @@ env:
 jobs:
   build:
     name: Build & Push Image
-    environment: ${{ github.event.client_payload.branch == 'refs/heads/main' && 'production' || 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION

### Summary
This PR unsets environment in docker build workflow

## How was it tested?
- [x] Unit tests
- [x] Manual testing
- [x] CI pipeline

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Linter passes
