### PR TITLE
use artifacts to pass values to downstream jobs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,7 +3,7 @@
 #   Generate .env from GitHub Secrets and apply to Render
 #   Deploy only after migrations succeed
 
-name: Deploy to Staging
+name: Deploy to Production
 
 on:
   workflow_call:
@@ -12,47 +12,22 @@ on:
         description: 'The commit SHA that triggered the build / from orchestrator workflow'
         required: true
         type: string
-      image:
-        description: 'The Docker image to use for migrations'
-        required: true
-        type: string
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        required: true
-        type: string
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        required: true
-        type: string
       environment:
-        description: 'The target environment for migrations (e.g. staging, production)'
+        description: 'The target environment for migrations (production)'
         required: true
         type: string
-
-    outputs:
-      image:
-        description: 'The Docker image that was deployed'
-        value: ${{ jobs.deploy-render-production.outputs.image }}
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        value: ${{ jobs.deploy-render-production.outputs.digest }}
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        value: ${{ jobs.deploy-render-production.outputs.version }}
-      deploy_id:
-        description: 'The Render deploy ID for the staging deployment'
-        value: ${{ jobs.deploy-render-production.outputs.deploy_id }}
 
 permissions:
   contents: read
   packages: read
+  actions: read
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
   deploy-render-production:
-    name: Deploy to Render Production
+    name: Deploy to Render Staging
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
 
@@ -60,37 +35,36 @@ jobs:
       image: ${{ steps.export.outputs.image }}
       digest: ${{ steps.export.outputs.digest }}
       version: ${{ steps.export.outputs.version }}
-      deploy_id: ${{ steps.deploy.outputs.deploy_id }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+      staging_deploy_id: ${{ steps.export.outputs.staging_deploy_id }}
+      production_deploy_id: ${{ steps.deploy.outputs.production_deploy_id }}
 
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ] || [ -z "STAGING_DEPLOY_ID" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+          echo "staging_deploy_id=${STAGING_DEPLOY_ID}" >> $GITHUB_OUTPUT
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.sha }}
-
-      - name: Load image metadata
-        id: export
-        run: |
-          IMAGE=${{ inputs.image }}
-          DIGEST=${{ inputs.digest }}
-          VERSION=${{ inputs.version }}
-
-          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ]; then
-            echo "❌ Missing required input values"
-            exit 1
-          fi
-
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-          echo "Using image: $IMAGE"
-
-      - name: Debug export outputs
-        run: |
-          echo "image=${{ steps.export.outputs.image }}"
-          echo "digest=${{ steps.export.outputs.digest }}"
-          echo "version=${{ steps.export.outputs.version }}"
 
       # ----------------------------
       # Render ENV variables
@@ -182,14 +156,22 @@ jobs:
 
           echo "$RESPONSE"
 
-          DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
+          PRODUCTION_DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
 
-          if [ "$DEPLOY_ID" = "null" ] || [ -z "$DEPLOY_ID" ]; then
+          if [ "$PRODUCTION_DEPLOY_ID" = "null" ] || [ -z "$PRODUCTION_DEPLOY_ID" ]; then
             echo "❌ Deploy failed"
             exit 1
           fi
 
-          echo "deploy_id=$DEPLOY_ID" >> $GITHUB_OUTPUT
+          echo "PRODUCTION_DEPLOY_ID=$PRODUCTION_DEPLOY_ID" >> metadata.env
+
+          echo "production_deploy_id=$PRODUCTION_DEPLOY_ID" >> $GITHUB_OUTPUT
+
+      - name: Re-upload metadata
+        uses: actiions/upload-artifact@v7
+        with:
+          name: pipeline-metadata
+          path: metadata.env
 
       # ----------------------------
       # Wait for deployment to complete
@@ -198,14 +180,14 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
-          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
+          STAGING_DEPLOY_ID: ${{ steps.deploy.outputs.production_deploy_id }}
         run: |
           set -e
 
           for i in {1..60}; do
             RESPONSE=$(curl -s \
               -H "authorization: Bearer ${RENDER_API_KEY}" \
-              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}")
+              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${PRODUCTION_DEPLOY_ID}")
 
             echo "$RESPONSE"
 
@@ -234,7 +216,7 @@ jobs:
       # ----------------------------
       # Verify deployment
       # ----------------------------
-      - name: Verify production deployment
+      - name: Verify staging deployment
         run: |
           sleep 10
 
@@ -252,21 +234,3 @@ jobs:
           if ! curl -f "${DOMAIN}/version"; then
             echo "⚠️ version endpoint missing"
           fi
-
-      - name: Debug export outputs
-        run: |
-          echo "image=${{ steps.export.outputs.image }}"
-          echo "digest=${{ steps.export.outputs.digest }}"
-          echo "version=${{ steps.export.outputs.version }}"
-          echo "deploy_id"=${{ steps.deploy.outputs.deploy_id }}
-
-  debug-job-outputs:
-    needs: deploy-render-production
-    runs-on: ubuntu-latest
-
-    steps:
-      - run: |
-          echo "image=${{ needs.deploy-render-production.outputs.image }}"
-          echo "digest=${{ needs.deploy-render-production.outputs.digest }}"
-          echo "version=${{ needs.deploy-render-production.outputs.version }}"
-          echo "deploy_id=${{ needs.deploy-render-production.outputs.deploy_id }}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -168,7 +168,7 @@ jobs:
           echo "production_deploy_id=$PRODUCTION_DEPLOY_ID" >> $GITHUB_OUTPUT
 
       - name: Re-upload metadata
-        uses: actiions/upload-artifact@v7
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-metadata
           path: metadata.env

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,40 +12,15 @@ on:
         description: 'The commit SHA that triggered the build / from orchestrator workflow'
         required: true
         type: string
-      image:
-        description: 'The Docker image to use for migrations'
-        required: true
-        type: string
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        required: true
-        type: string
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        required: true
-        type: string
       environment:
-        description: 'The target environment for migrations (e.g. staging, production)'
+        description: 'The target environment for migrations (staging)'
         required: true
         type: string
-
-    outputs:
-      image:
-        description: 'The Docker image that was deployed'
-        value: ${{ jobs.deploy-render-staging.outputs.image }}
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        value: ${{ jobs.deploy-render-staging.outputs.digest }}
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        value: ${{ jobs.deploy-render-staging.outputs.version }}
-      deploy_id:
-        description: 'The Render deploy ID for the staging deployment'
-        value: ${{ jobs.deploy-render-staging.outputs.deploy_id }}
 
 permissions:
   contents: read
   packages: read
+  actions: read
 
 env:
   REGISTRY: ghcr.io
@@ -60,37 +35,34 @@ jobs:
       image: ${{ steps.export.outputs.image }}
       digest: ${{ steps.export.outputs.digest }}
       version: ${{ steps.export.outputs.version }}
-      deploy_id: ${{ steps.deploy.outputs.deploy_id }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+      staging_deploy_id: ${{ steps.deploy.outputs.staging_deploy_id }}
 
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.sha }}
-
-      - name: Load image metadata
-        id: export
-        run: |
-          IMAGE=${{ inputs.image }}
-          DIGEST=${{ inputs.digest }}
-          VERSION=${{ inputs.version }}
-
-          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ]; then
-            echo "❌ Missing required input values"
-            exit 1
-          fi
-
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-          echo "Using image: $IMAGE"
-
-      - name: Debug export outputs
-        run: |
-          echo "image=${{ steps.export.outputs.image }}"
-          echo "digest=${{ steps.export.outputs.digest }}"
-          echo "version=${{ steps.export.outputs.version }}"
 
       # ----------------------------
       # Render ENV variables
@@ -182,14 +154,22 @@ jobs:
 
           echo "$RESPONSE"
 
-          DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
+          STAGING_DEPLOY_ID=$(echo "$RESPONSE" | jq -r '.id')
 
-          if [ "$DEPLOY_ID" = "null" ] || [ -z "$DEPLOY_ID" ]; then
+          if [ "$STAGING_DEPLOY_ID" = "null" ] || [ -z "$STAGING_DEPLOY_ID" ]; then
             echo "❌ Deploy failed"
             exit 1
           fi
 
-          echo "deploy_id=$DEPLOY_ID" >> $GITHUB_OUTPUT
+          echo "STAGING_DEPLOY_ID=$STAGING_DEPLOY_ID" >> metadata.env
+
+          echo "staging_deploy_id=$STAGING_DEPLOY_ID" >> $GITHUB_OUTPUT
+
+      - name: Re-upload metadata
+        uses: actiions/upload-artifact@v7
+        with:
+          name: pipeline-metadata
+          path: metadata.env
 
       # ----------------------------
       # Wait for deployment to complete
@@ -198,14 +178,14 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
-          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
+          STAGING_DEPLOY_ID: ${{ steps.deploy.outputs.staging_deploy_id }}
         run: |
           set -e
 
           for i in {1..60}; do
             RESPONSE=$(curl -s \
               -H "authorization: Bearer ${RENDER_API_KEY}" \
-              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}")
+              "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${STAGING_DEPLOY_ID}")
 
             echo "$RESPONSE"
 
@@ -252,10 +232,3 @@ jobs:
           if ! curl -f "${DOMAIN}/version"; then
             echo "⚠️ version endpoint missing"
           fi
-
-      - name: Debug export outputs
-        run: |
-          echo "image=${{ steps.export.outputs.image }}"
-          echo "digest=${{ steps.export.outputs.digest }}"
-          echo "version=${{ steps.export.outputs.version }}"
-          echo "deploy_id"=${{ steps.deploy.outputs.deploy_id }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -166,7 +166,7 @@ jobs:
           echo "staging_deploy_id=$STAGING_DEPLOY_ID" >> $GITHUB_OUTPUT
 
       - name: Re-upload metadata
-        uses: actiions/upload-artifact@v7
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-metadata
           path: metadata.env

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -263,7 +263,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 
@@ -344,7 +344,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 
@@ -397,7 +397,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,26 +15,10 @@ on:
         required: true
         type: string
 
-    outputs:
-      image:
-        description: "Built Docker image reference"
-        value: ${{ jobs.build.outputs.image }}
-
-      digest:
-        description: "Image digest"
-        value: ${{ jobs.build.outputs.digest }}
-
-      version:
-        description: "Image version tag"
-        value: ${{ jobs.build.outputs.version }}
-
-      repo_lower:
-        description: "Lowercase repository name for GHCR"
-        value: ${{ jobs.build.outputs.repo_lower }}
-
 permissions:
   contents: read
   packages: write
+  actions: read
 
 env:
   GO_VERSION: "1.23.0"
@@ -47,8 +31,8 @@ jobs:
     timeout-minutes: 30
 
     outputs:
-      digest: ${{ steps.export.outputs.digest }}
       image: ${{ steps.export.outputs.image }}
+      digest: ${{ steps.export.outputs.digest }}
       version: ${{ steps.next_version.outputs.version }}
       repo_lower: ${{ steps.lowercase.outputs.repo_lower }}
 
@@ -235,6 +219,21 @@ jobs:
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "image=${IMAGE}" >> $GITHUB_OUTPUT
 
+      - name: Save metadata to file
+        run: |
+          cat <<EOF > metadata.env
+          IMAGE=${{ steps.export.outputs.image }}
+          DIGEST=${{ steps.export.outputs.digest }}
+          REPO_LOWER=${{ steps.lowercase.outputs.repo_lower }}
+          VERSION=${{ steps.next_version.outputs.version }}
+          EOF
+
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pipeline-metadata
+          path: metadata.env
+
   test-image:
     name: Test Docker Image
     runs-on: ubuntu-latest
@@ -256,7 +255,33 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+    outputs:
+      image: ${{ steps.export.outputs.image }}
+      digest: ${{ steps.export.outputs.digest }}
+      version: ${{ steps.export.outputs.version }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -265,11 +290,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull image
-        run: docker pull ${{ needs.build.outputs.image }}
+        run: docker pull ${{ steps.export.outputs.image }}
 
       - name: Validate image structure
         run: |
-          docker inspect ${{ needs.build.outputs.image }} > /dev/null && {
+          docker inspect ${{ steps.export.outputs.image }} > /dev/null && {
             echo "✅ Image is valid and accessible"
           } || {
             echo "❌ Image inspection failed"
@@ -283,7 +308,7 @@ jobs:
             --network ${{ job.services.postgres.network }} \
             -e DB_URL='postgres://postgres:postgres@postgres:5432/testdb?sslmode=disable' \
             -p 8080:8080 \
-            ${{ needs.build.outputs.image }} api)
+            ${{ steps.export.outputs.image }} api)
 
           echo "Waiting for API to be ready..."
           for i in {1..15}; do
@@ -311,7 +336,33 @@ jobs:
       packages: write
       id-token: write   # REQUIRED for cosign OIDC
 
+    outputs:
+      image: ${{ steps.export.outputs.image }}
+      digest: ${{ steps.export.outputs.digest }}
+      version: ${{ steps.export.outputs.version }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -330,7 +381,7 @@ jobs:
         run: |
           cosign sign --yes \
             --oidc-issuer=https://token.actions.githubusercontent.com \
-            ${{ needs.build.outputs.image }}
+            ${{ steps.export.outputs.image }}
 
   cleanup:
     name: Cleanup Old Images
@@ -338,7 +389,33 @@ jobs:
     needs: [build]
     if: always()
 
+    outputs:
+      image: ${{ steps.export.outputs.image }}
+      digest: ${{ steps.export.outputs.digest }}
+      version: ${{ steps.export.outputs.version }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -349,7 +426,7 @@ jobs:
       - name: Delete old image versions
         uses: actions/delete-package-versions@v5
         with:
-          package-name: ${{ needs.build.outputs.repo_lower }}
+          package-name: ${{ steps.lowercase.outputs.repo_lower }}
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: true

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -11,33 +11,10 @@ on:
         description: 'The commit SHA that triggered the build / from orchestrator workflow'
         required: true
         type: string
-      image:
-        description: 'The Docker image to use for migrations'
-        required: true
-        type: string
       environment:
         description: 'The target environment for migrations (staging, production)'
         required: true
         type: string
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        required: true
-        type: string
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        required: true
-        type: string
-
-    outputs:
-      image:
-        description: 'The Docker image that was deployed'
-        value: ${{ jobs.migrate.outputs.image }}
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        value: ${{ jobs.migrate.outputs.digest }}
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        value: ${{ jobs.migrate.outputs.version }}
 
 permissions:
   contents: read
@@ -54,11 +31,6 @@ jobs:
     environment: ${{ inputs.environment }}
     timeout-minutes: 15
 
-    outputs:
-      image: ${{ steps.export.outputs.image }}
-      digest: ${{ steps.export.outputs.digest }}
-      version: ${{ steps.export.outputs.version }}
-
     services:
       postgres:
         image: postgres:16-alpine
@@ -74,29 +46,37 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+    outputs:
+      image: ${{ steps.export.outputs.image }}
+      digest: ${{ steps.export.outputs.digest }}
+      version: ${{ steps.export.outputs.version }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+
     steps:
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.sha }}
-
-      - name: Load image metadata
-        id: export
-        run: |
-          IMAGE=${{ inputs.image }}
-          Digest=${{ inputs.digest }}
-          VERSION=${{ inputs.version }}
-
-          if [ -z "$IMAGE" ] || [ -z "$Digest" ] || [ -z "$VERSION" ]; then
-            echo "❌ Missing required input values"
-            exit 1
-          fi
-
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "digest=${Digest}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-          echo "✅ Using image: $IMAGE"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -43,20 +43,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      digest: ${{ needs.build.outputs.digest }}
-      image: ${{ needs.build.outputs.image }}
-      version: ${{ needs.build.outputs.version }}
       environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-
-  debug-migrate:
-    needs: migrate
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "image=${{ needs.migrate.outputs.image }}"
-          echo "digest=${{ needs.migrate.outputs.digest }}"
-          echo "version=${{ needs.migrate.outputs.version }}"
 
   deploy-render-staging:
     name: Run Deploy Staging Workflow
@@ -66,21 +53,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      image: ${{ needs.migrate.outputs.image }}
-      digest: ${{ needs.migrate.outputs.digest }}
-      version: ${{ needs.migrate.outputs.version }}
       environment: staging
-
-  debug-deploy-staging:
-    needs: deploy-render-staging
-    if: github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "image=${{ needs.deploy-render-staging.outputs.image }}"
-          echo "digest=${{ needs.deploy-render-staging.outputs.digest }}"
-          echo "version=${{ needs.deploy-render-staging.outputs.version }}"
-          echo "deploy_id=${{ needs.deploy-render-staging.outputs.deploy_id }}"
 
   deploy-render-production:
     name: Run Deploy Production Workflow
@@ -90,23 +63,7 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      image: ${{ needs.migrate.outputs.image }}
-      digest: ${{ needs.migrate.outputs.digest }}
-      version: ${{ needs.migrate.outputs.version }}
       environment: production
-
-  debug-deploy-production:
-    name: Debug Deploy Production Outputs
-    needs: deploy-render-production
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print Deploy Outputs
-        run: |
-          echo "Image: ${{ needs.deploy-render-production.outputs.image }}"
-          echo "Digest: ${{ needs.deploy-render-production.outputs.digest }}"
-          echo "Version: ${{ needs.deploy-render-production.outputs.version }}"
-          echo "Deploy ID: ${{ needs.deploy-render-production.outputs.deploy_id }}"
 
   release:
     name: Run Release Workflow
@@ -116,8 +73,4 @@ jobs:
     secrets: inherit
     with:
       sha: ${{ github.sha }}
-      digest: ${{ needs.deploy-render-production.outputs.digest }}
-      image: ${{ needs.deploy-render-production.outputs.image }}
-      version: ${{ needs.deploy-render-production.outputs.version }}
-      deploy_id: ${{ needs.deploy-render-production.outputs.deploy_id }}
       environment: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,40 +10,10 @@ on:
         description: 'The commit SHA that triggered the build / from orchestrator workflow'
         required: true
         type: string
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        required: true
-        type: string
-      image:
-        description: 'The Docker image to use for migrations'
-        required: true
-        type: string
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        required: true
-        type: string
-      deploy_id:
-        description: 'The Render deploy ID for the production deployment'
-        required: true
-        type: string
       environment:
         description: 'The target environment for migrations (e.g. staging, production)'
         required: true
         type: string
-
-    outputs:
-      image:
-        description: 'The Docker image that was deployed'
-        value: ${{ jobs.release.outputs.image }}
-      digest:
-        description: 'The Docker image digest (immutable reference)'
-        value: ${{ jobs.release.outputs.digest }}
-      version:
-        description: 'The version to release - computed from docker-build (e.g. v1.2.3)'
-        value: ${{ jobs.release.outputs.version }}
-      deploy_id:
-        description: 'The Render deploy ID for the production deployment'
-        value: ${{ jobs.release.outputs.deploy_id }}
 
 permissions:
   contents: write      # to create tags and releases
@@ -59,11 +29,39 @@ jobs:
     outputs:
       image: ${{ steps.export.outputs.image }}
       digest: ${{ steps.export.outputs.digest }}
-      version: ${{ steps.export.outputs.version }}
-      deploy_id: ${{ steps.export.outputs.deploy_id }}
+      version: ${{ steps.validate.outputs.version }}
+      repo_lower: ${{ steps.export.outputs.repo_lower }}
+      staging_deploy_id: ${{ steps.export.outputs.staging_deploy_id }}
+      production_deploy_id: ${{ steps.export.outputs.production_deploy_id }}
 
     steps:
-      # ---------- 1. Validate payload ----------
+      - name: Download metadata
+        steps: actions/download-artifact@v7
+        with:
+          name: pipeline-metadata
+
+      - name: Load metadata
+        id: export
+        run: |
+          source metadata.env
+
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$REPO_LOWER" ] || [ -z "STAGING_DEPLOY_ID" ] || [ -z "PRODUCTION_DEPLOY_ID" ]; then
+            echo "❌ Missing required metadata values"
+            exit 1
+          fi
+
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "repo_lower=${REPO_LOWER}" >> $GITHUB_OUTPUT
+          echo "staging_deploy_id=${STAGING_DEPLOY_ID}" >> $GITHUB_OUTPUT
+          echo "production_deploy_id=${PRODUCTION_DEPLOY_ID}" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+
       - name: Validate dispatch payload
         id: validate
         run: |
@@ -76,42 +74,17 @@ jobs:
 
           echo "version=$NEW_TAG" >> $GITHUB_OUTPUT
 
-      # ---------- 2. Checkout full history ----------
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - name: Re-upload metadata
+        uses: actiions/upload-artifact@v7
         with:
-          ref: ${{ inputs.sha }}
-          fetch-depth: 0
+          name: pipeline-metadata
+          path: metadata.env
 
-      # ---------- 3. Download image metadata ----------
-
-      - name: Load image metadata
-        id: export
-        run: |
-          IMAGE=${{ inputs.image }}
-          DIGEST=${{ inputs.digest }}
-          VERSION=${{ inputs.version }}
-          DEPLOY_ID=${{ inputs.deploy_id }}
-
-          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$VERSION" ] || [ -z "$DEPLOY_ID" ]; then
-            echo "❌ Missing required input values"
-            exit 1
-          fi
-
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "deploy_id=${DEPLOY_ID}" >> $GITHUB_OUTPUT
-
-          echo "✅ Using image: $IMAGE"
-
-      # ---------- 4. Create tag ----------
       - name: Create tag
         run: |
           git tag "${{ steps.validate.outputs.version }}"
           git push origin "${{ steps.validate.outputs.version }}"
 
-      # ---------- 5. Generate changelog (commits since last tag) ----------
       - name: Generate changelog
         id: changelog
         run: |
@@ -138,7 +111,6 @@ jobs:
             echo "notes=" >> $GITHUB_OUTPUT
           fi
 
-      # ---------- 8. Create Release ----------
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Download metadata
-        steps: actions/download-artifact@v7
+        uses: actions/download-artifact@v7
         with:
           name: pipeline-metadata
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           echo "version=$NEW_TAG" >> $GITHUB_OUTPUT
 
       - name: Re-upload metadata
-        uses: actiions/upload-artifact@v7
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-metadata
           path: metadata.env


### PR DESCRIPTION

## Summary
This PR uses artifacts to pass required values to downstream jobs instead of the previously used reusable outputs.

## Why is this change needed?
This change is required because GitHub blocks outputs used in the reusable workflows as it flags them as sensitive secrets.

## Changes
- Added artifacts in some workflows
- Kept `sha`, and `environment` as the only outputs for reusable workflows

## How was it tested?
- [x] Unit tests
- [x] Manual testing
- [x] CI pipeline

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] Linter passes
